### PR TITLE
refactor: 조직명과 프로젝트 Prefix 중복으로 인한 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ kr.hhplus.be.server
 1. 코드 클론:
 
     ```bash
-    git clone https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java.git
-    cd hhplus-e-commerce-java
+    git clone https://github.com/hanghae-plus-anveloper/e-commerce.git
+    cd e-commerce
     ```
 
 2. 환경 파일 설정:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HHPlus E-Commerce (Java Backend)
+# E-Commerce (Java Backend)
 
 > Java Spring Boot 기반 전자상거래 백엔드 서비스.  
 > 사용자, 상품, 쿠폰, 잔액, 주문을 중심으로 도메인 주도 설계(DDD)와 계층형 아키텍처를 적용한 프로젝트입니다.   
@@ -8,7 +8,7 @@
 
 ## 목차
 
-- [HHPlus E-Commerce (Java Backend)](#hhplus-e-commerce-java-backend)
+- [E-Commerce (Java Backend)](#e-commerce-java-backend)
   - [목차](#목차)
   - [프로젝트 개요](#프로젝트-개요)
   - [아키텍처 및 설계](#아키텍처-및-설계)
@@ -31,7 +31,7 @@
 
 ## 프로젝트 개요
 
-HHPlus E-Commerce Java 백엔드 서비스는 다음 기능들을 제공합니다:
+E-Commerce Java 백엔드 서비스는 다음 기능들을 제공합니다:
 
 - 사용자 조회 및 관리
 - 잔액(Balance) 조회, 충전, 사용

--- a/docs/asynchronous-kafka/design.md
+++ b/docs/asynchronous-kafka/design.md
@@ -105,7 +105,7 @@
 
 ## 기능 구현
 
-- [CouponService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponService.java): `CouponService.tryIssue` 이벤트 발행 추가
+- [CouponService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/coupon/application/CouponService.java): `CouponService.tryIssue` 이벤트 발행 추가
   ```java
   public boolean tryIssue(Long userId, Long policyId) {
     boolean accepted = couponRedisRepository.tryIssue(userId, policyId);
@@ -117,7 +117,7 @@
   ```
   - Redis에 쿠폰 발급 요청 적재 시 **적재됨** 이벤트 발행
 
-- [CouponWorker.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponWorker.java)
+- [CouponWorker.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/coupon/application/CouponWorker.java)
   ```java
   // 확정처리는 Kafka로 이전
   // @Scheduled(fixedDelay = 1000) // 1초마다 실행
@@ -125,7 +125,7 @@
   ```
   - 기존 배치 스케쥴러는 제외처리
 
-- [KafkaTopics.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/kafka/KafkaTopics.java): 토픽 변경
+- [KafkaTopics.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/kafka/KafkaTopics.java): 토픽 변경
   ```java
   @Bean
   NewTopic couponPendedTopic(
@@ -137,17 +137,17 @@
   ```
   - coupon-issued나 coupon-issue-requested 보단 현재 상태인 pended 사실 기반으로 변경
 
-- [CouponPendedEvent.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/common/event/coupon/CouponPendedEvent.java)
+- [CouponPendedEvent.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/common/event/coupon/CouponPendedEvent.java)
   ```java
   public record CouponPendedEvent(Long userId, Long policyId) {} 
   ```
 
-- [CouponPendedMessage.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/kafka/message/OrderCompletedMessage.java)
+- [CouponPendedMessage.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/kafka/message/OrderCompletedMessage.java)
   ```java
   public record CouponPendedMessage(Long userId, Long policyId, Instant requestedAt) {}
   ```
 
-- [OrderCompletedKafkaPublisher.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/kafka/publisher/OrderCompletedKafkaPublisher.java)
+- [OrderCompletedKafkaPublisher.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/kafka/publisher/OrderCompletedKafkaPublisher.java)
   ```java
   @Slf4j
   @Component
@@ -179,7 +179,7 @@
     - RedisRepository는 트랜젝션이 아니어서 직접 발행해도 될 것으로 보이나, 
     - 분리 시 로깅이나 메세지 발행 재시도 로직을 넣기에 용이할것으로 보여 구성
 
-- [KafkaCouponConsumerConfig.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/kafka/config/KafkaCouponConsumerConfig.java)
+- [KafkaCouponConsumerConfig.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/kafka/config/KafkaCouponConsumerConfig.java)
   ```java
   @EnableKafka
   @Configuration
@@ -216,7 +216,7 @@
     - Producer의 타입헤더가 불일치하더라도 무시가능, 보안 리스크 경감
     - 메세지 스키마 고정으로 일관성 유지, 다른 컨슈머와 섞이지 않음
 
-- [CouponIssueKafkaConsumer.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/kafka/consumer/CouponIssueKafkaConsumer.java) 
+- [CouponIssueKafkaConsumer.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/kafka/consumer/CouponIssueKafkaConsumer.java) 
   ```java
   @Slf4j
   @Component
@@ -248,7 +248,7 @@
 
 ### 조건
 
-- [CouponServiceKafkaTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/coupon/application/CouponServiceKafkaTest.java)
+- [CouponServiceKafkaTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/test/java/kr/hhplus/be/server/coupon/application/CouponServiceKafkaTest.java)
 - 4개의 정책을 설정하고, 각각의 발급 수량을 200로 제한하여, 각 쿠폰 정책별 1000번의 요청을 시도한다.
 - 800건의 kafka 메세지 발행을 확인한다.
 

--- a/docs/asynchronous-kafka/design.md
+++ b/docs/asynchronous-kafka/design.md
@@ -105,7 +105,7 @@
 
 ## 기능 구현
 
-- [CouponService.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponService.java): `CouponService.tryIssue` 이벤트 발행 추가
+- [CouponService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponService.java): `CouponService.tryIssue` 이벤트 발행 추가
   ```java
   public boolean tryIssue(Long userId, Long policyId) {
     boolean accepted = couponRedisRepository.tryIssue(userId, policyId);
@@ -117,7 +117,7 @@
   ```
   - Redis에 쿠폰 발급 요청 적재 시 **적재됨** 이벤트 발행
 
-- [CouponWorker.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponWorker.java)
+- [CouponWorker.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponWorker.java)
   ```java
   // 확정처리는 Kafka로 이전
   // @Scheduled(fixedDelay = 1000) // 1초마다 실행
@@ -125,7 +125,7 @@
   ```
   - 기존 배치 스케쥴러는 제외처리
 
-- [KafkaTopics.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/kafka/KafkaTopics.java): 토픽 변경
+- [KafkaTopics.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/kafka/KafkaTopics.java): 토픽 변경
   ```java
   @Bean
   NewTopic couponPendedTopic(
@@ -137,17 +137,17 @@
   ```
   - coupon-issued나 coupon-issue-requested 보단 현재 상태인 pended 사실 기반으로 변경
 
-- [CouponPendedEvent.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/common/event/coupon/CouponPendedEvent.java)
+- [CouponPendedEvent.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/common/event/coupon/CouponPendedEvent.java)
   ```java
   public record CouponPendedEvent(Long userId, Long policyId) {} 
   ```
 
-- [CouponPendedMessage.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/kafka/message/OrderCompletedMessage.java)
+- [CouponPendedMessage.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/kafka/message/OrderCompletedMessage.java)
   ```java
   public record CouponPendedMessage(Long userId, Long policyId, Instant requestedAt) {}
   ```
 
-- [OrderCompletedKafkaPublisher.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/kafka/publisher/OrderCompletedKafkaPublisher.java)
+- [OrderCompletedKafkaPublisher.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/kafka/publisher/OrderCompletedKafkaPublisher.java)
   ```java
   @Slf4j
   @Component
@@ -179,7 +179,7 @@
     - RedisRepository는 트랜젝션이 아니어서 직접 발행해도 될 것으로 보이나, 
     - 분리 시 로깅이나 메세지 발행 재시도 로직을 넣기에 용이할것으로 보여 구성
 
-- [KafkaCouponConsumerConfig.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/kafka/config/KafkaCouponConsumerConfig.java)
+- [KafkaCouponConsumerConfig.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/kafka/config/KafkaCouponConsumerConfig.java)
   ```java
   @EnableKafka
   @Configuration
@@ -216,7 +216,7 @@
     - Producer의 타입헤더가 불일치하더라도 무시가능, 보안 리스크 경감
     - 메세지 스키마 고정으로 일관성 유지, 다른 컨슈머와 섞이지 않음
 
-- [CouponIssueKafkaConsumer.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/kafka/consumer/CouponIssueKafkaConsumer.java) 
+- [CouponIssueKafkaConsumer.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/kafka/consumer/CouponIssueKafkaConsumer.java) 
   ```java
   @Slf4j
   @Component
@@ -248,7 +248,7 @@
 
 ### 조건
 
-- [CouponServiceKafkaTest.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/test/java/kr/hhplus/be/server/coupon/application/CouponServiceKafkaTest.java)
+- [CouponServiceKafkaTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/coupon/application/CouponServiceKafkaTest.java)
 - 4개의 정책을 설정하고, 각각의 발급 수량을 200로 제한하여, 각 쿠폰 정책별 1000번의 요청을 시도한다.
 - 800건의 kafka 메세지 발행을 확인한다.
 

--- a/docs/asynchronous-redis/design.md
+++ b/docs/asynchronous-redis/design.md
@@ -122,7 +122,7 @@ sequenceDiagram
 
 ### 조건
 
-- [CouponRedisServiceTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/coupon/application/CouponRedisServiceTest.java)
+- [CouponRedisServiceTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/test/java/kr/hhplus/be/server/coupon/application/CouponRedisServiceTest.java)
 - 1000개가 가용한 쿠폰에 대하여 사용자 요청은 2000개 수행
 - 사용자 요청은 200개씩 10번 동시요청으로 수행(ms 값 중복 발생 테스트용)
   - 워커는 500개씩 처리시켜볼 예정이고, ms + 랜덤숫자는 3자리 숫자 001~999까지 부여할 예정입니다.
@@ -196,7 +196,7 @@ sequenceDiagram
 
 ### 클래스 별 기는 상세
 
-- [CouponRedisKey.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponRedisKey.java)
+- [CouponRedisKey.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/coupon/application/CouponRedisKey.java)
   - Key를 일관성 있게 관리하기 위한 유틸리티 클래스
   - 쿠폰 정책별로 남은 수량(REMAINING), 대기열(PENDING), 발급 완료(ISSUED) 키를 생성
     ```java
@@ -223,7 +223,7 @@ sequenceDiagram
       - Redis의 SET 구조를 사용하며, 중복 발급 차단과 이력 관리에 활용됩니다.
 
 
-- [CouponRedisService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponRedisService.java)
+- [CouponRedisService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/coupon/application/CouponRedisService.java)
   - 쿠폰 발급 요청이 Redis를 통해 처리될 수 있도록 지원하는 서비스 계층
     - 기존 `CouponFacade`에서의 요청을 처리하던 CouponService(DB) 대신에 발급 성공/실패 여부를 미리 반환합니다.   
   - 발급 요청을 Redis에 기록하고, Worker가 처리할 수 있도록 데이터를 관리하는 역할을 수행
@@ -327,7 +327,7 @@ sequenceDiagram
     - `clearAll()`
       - 테스트나 초기화 시 모든 쿠폰 정책 관련 Redis Key를 정리합니다.
 
-- [CouponWorker.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponWorker.java)
+- [CouponWorker.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/coupon/application/CouponWorker.java)
   - Redis에 쌓인 대기열(PENDING) 을 주기적으로 처리하여 DB에 발급을 확정하는 역할을 수행
   - DB를 주기적으로 조회하여 현재 유효한 정책 목록으로 Redis의 정책-남은 수량을 업데이트
   - Redis를 주기적으로 조회하여 PENDING 상태의 쿠폰 발급 요청을 특정 수만큼 가져와 순차적으로 쿠폰 발급
@@ -401,7 +401,7 @@ sequenceDiagram
       - 각 사용자에 대해 `CouponService.issueCoupon`을 호출하여 DB에 발급 확정
       - 처리된 요청은 `ZSET`에서 제거
 
-- [CouponService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponService.java) 기능 추가/변경
+- [CouponService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/coupon/application/CouponService.java) 기능 추가/변경
   ```java
   @Transactional(readOnly = true)
   public List<CouponPolicy> getActivePolicies() {
@@ -418,7 +418,7 @@ sequenceDiagram
   - DB에서 유효한 정책 조회 함수 추가 
   - issueCoupon 호출 시 User → UserId로 변경 
   
-- [Coupon.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/domain/Coupon.java) 변경
+- [Coupon.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/coupon/domain/Coupon.java) 변경
   - JPA 매핑 방식 변경
     - Redis 에서 userId와 policyId 만으로 조회하기 용이하도록, 연관관계 매핑에서 FK 식별자로 직접 매핑으로 리팩토링
   - 변경전

--- a/docs/asynchronous-redis/design.md
+++ b/docs/asynchronous-redis/design.md
@@ -122,7 +122,7 @@ sequenceDiagram
 
 ### 조건
 
-- [CouponRedisServiceTest.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/test/java/kr/hhplus/be/server/coupon/application/CouponRedisServiceTest.java)
+- [CouponRedisServiceTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/coupon/application/CouponRedisServiceTest.java)
 - 1000개가 가용한 쿠폰에 대하여 사용자 요청은 2000개 수행
 - 사용자 요청은 200개씩 10번 동시요청으로 수행(ms 값 중복 발생 테스트용)
   - 워커는 500개씩 처리시켜볼 예정이고, ms + 랜덤숫자는 3자리 숫자 001~999까지 부여할 예정입니다.
@@ -196,7 +196,7 @@ sequenceDiagram
 
 ### 클래스 별 기는 상세
 
-- [CouponRedisKey.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponRedisKey.java)
+- [CouponRedisKey.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponRedisKey.java)
   - Key를 일관성 있게 관리하기 위한 유틸리티 클래스
   - 쿠폰 정책별로 남은 수량(REMAINING), 대기열(PENDING), 발급 완료(ISSUED) 키를 생성
     ```java
@@ -223,7 +223,7 @@ sequenceDiagram
       - Redis의 SET 구조를 사용하며, 중복 발급 차단과 이력 관리에 활용됩니다.
 
 
-- [CouponRedisService.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponRedisService.java)
+- [CouponRedisService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponRedisService.java)
   - 쿠폰 발급 요청이 Redis를 통해 처리될 수 있도록 지원하는 서비스 계층
     - 기존 `CouponFacade`에서의 요청을 처리하던 CouponService(DB) 대신에 발급 성공/실패 여부를 미리 반환합니다.   
   - 발급 요청을 Redis에 기록하고, Worker가 처리할 수 있도록 데이터를 관리하는 역할을 수행
@@ -327,7 +327,7 @@ sequenceDiagram
     - `clearAll()`
       - 테스트나 초기화 시 모든 쿠폰 정책 관련 Redis Key를 정리합니다.
 
-- [CouponWorker.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponWorker.java)
+- [CouponWorker.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponWorker.java)
   - Redis에 쌓인 대기열(PENDING) 을 주기적으로 처리하여 DB에 발급을 확정하는 역할을 수행
   - DB를 주기적으로 조회하여 현재 유효한 정책 목록으로 Redis의 정책-남은 수량을 업데이트
   - Redis를 주기적으로 조회하여 PENDING 상태의 쿠폰 발급 요청을 특정 수만큼 가져와 순차적으로 쿠폰 발급
@@ -401,7 +401,7 @@ sequenceDiagram
       - 각 사용자에 대해 `CouponService.issueCoupon`을 호출하여 DB에 발급 확정
       - 처리된 요청은 `ZSET`에서 제거
 
-- [CouponService.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponService.java) 기능 추가/변경
+- [CouponService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponService.java) 기능 추가/변경
   ```java
   @Transactional(readOnly = true)
   public List<CouponPolicy> getActivePolicies() {
@@ -418,7 +418,7 @@ sequenceDiagram
   - DB에서 유효한 정책 조회 함수 추가 
   - issueCoupon 호출 시 User → UserId로 변경 
   
-- [Coupon.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/coupon/domain/Coupon.java) 변경
+- [Coupon.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/domain/Coupon.java) 변경
   - JPA 매핑 방식 변경
     - Redis 에서 userId와 policyId 만으로 조회하기 용이하도록, 연관관계 매핑에서 FK 식별자로 직접 매핑으로 리팩토링
   - 변경전

--- a/docs/cache-redis/report.md
+++ b/docs/cache-redis/report.md
@@ -44,7 +44,7 @@
 
 ### 통합 테스트 코드 및 Top Products 조회 계층 배치
 
-- [TopProductQueryServiceTest.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/test/java/kr/hhplus/be/server/analytics/application/TopProductQueryServiceTest.java)
+- [TopProductQueryServiceTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/analytics/application/TopProductQueryServiceTest.java)
   - 테스트 흐름
     - 더미 상품을 6가지 생성 후 3일 치 주문 아이템 생성 저장
       - 1번부터 6번까지 총 수량이 적어지는 방향으로 3일에 각각 나눠서 생성
@@ -99,7 +99,7 @@
 
 ### 상품 조회 로직 구현
 
-- [TopProductNativeRepository.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/analytics/domain/TopProductNativeRepository.java)
+- [TopProductNativeRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/analytics/domain/TopProductNativeRepository.java)
   - 시작일자, 종료일자, 획득할 상품수를 받아 상위 상품 목록을 반환하는 함수 구현
    
     ![조회 성공 1](./assets/002-top-products-success-no-cache.png)
@@ -111,11 +111,11 @@
 
 ### Cache 환경 설정
 
-- [RadissonCacheConfig.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/config/redis/RadissonCacheConfig.java)
+- [RadissonCacheConfig.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/config/redis/RadissonCacheConfig.java)
   - cacheManager 를 Bean으로 등록하여 cacheName 별 TTL 설정
   - CacheNames.TOP_PRODUCTS는 자정을 기준으로 초기화 하기 위해, 캐시된 시간으로부터 자정 + 지터값을 적용하여 TTL에 설정, maxIdleTime은 0으로 비활성(자정까지 유지)
-- [CacheNames.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/common/cache/CacheNames.java): cacheName 상수
-- [CacheKey.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/common/cache/CacheKey.java)
+- [CacheNames.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/common/cache/CacheNames.java): cacheName 상수
+- [CacheKey.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/common/cache/CacheKey.java)
   - 캐시 키 ENUM 값
   - "CACHE:TOP_PRODUCTS", "CACHE:PRODUCT", "CACHE:BALANCE"처럼 고정된 Prefix를 Enum 상수로 정의.
   - key(Object... parts) 메서드로 prefix 뒤에 여러 파라미터를 붙여 최종 캐시 키 문자열 생성.
@@ -123,7 +123,7 @@
 
 ### 캐싱 구현
 
-- [TopProductQueryService.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/analytics/application/TopProductQueryService.java)
+- [TopProductQueryService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/analytics/application/TopProductQueryService.java)
   - `@CacheConfig(cacheNames = CacheNames.TOP_PRODUCTS)` 클래스 레벨 지정하여, 각 함수에서 생략
   - 기본 기능 `top5InLast3Days` 는 확장 가능한 `topNLastNDays`함수를 호출하되, 클래스 내부에서 호출하므로, 각각 `@Cacheable`을 적용
   - `top5InLast3Days`는 3일 5개로 고정된 키 발행, `topNLastNDays`는 파라미터에 의해 발행

--- a/docs/cache-redis/report.md
+++ b/docs/cache-redis/report.md
@@ -44,7 +44,7 @@
 
 ### 통합 테스트 코드 및 Top Products 조회 계층 배치
 
-- [TopProductQueryServiceTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/analytics/application/TopProductQueryServiceTest.java)
+- [TopProductQueryServiceTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/test/java/kr/hhplus/be/server/analytics/application/TopProductQueryServiceTest.java)
   - 테스트 흐름
     - 더미 상품을 6가지 생성 후 3일 치 주문 아이템 생성 저장
       - 1번부터 6번까지 총 수량이 적어지는 방향으로 3일에 각각 나눠서 생성
@@ -99,7 +99,7 @@
 
 ### 상품 조회 로직 구현
 
-- [TopProductNativeRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/analytics/domain/TopProductNativeRepository.java)
+- [TopProductNativeRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/analytics/domain/TopProductNativeRepository.java)
   - 시작일자, 종료일자, 획득할 상품수를 받아 상위 상품 목록을 반환하는 함수 구현
    
     ![조회 성공 1](./assets/002-top-products-success-no-cache.png)
@@ -111,11 +111,11 @@
 
 ### Cache 환경 설정
 
-- [RadissonCacheConfig.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/config/redis/RadissonCacheConfig.java)
+- [RadissonCacheConfig.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/config/redis/RadissonCacheConfig.java)
   - cacheManager 를 Bean으로 등록하여 cacheName 별 TTL 설정
   - CacheNames.TOP_PRODUCTS는 자정을 기준으로 초기화 하기 위해, 캐시된 시간으로부터 자정 + 지터값을 적용하여 TTL에 설정, maxIdleTime은 0으로 비활성(자정까지 유지)
-- [CacheNames.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/common/cache/CacheNames.java): cacheName 상수
-- [CacheKey.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/common/cache/CacheKey.java)
+- [CacheNames.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/common/cache/CacheNames.java): cacheName 상수
+- [CacheKey.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/common/cache/CacheKey.java)
   - 캐시 키 ENUM 값
   - "CACHE:TOP_PRODUCTS", "CACHE:PRODUCT", "CACHE:BALANCE"처럼 고정된 Prefix를 Enum 상수로 정의.
   - key(Object... parts) 메서드로 prefix 뒤에 여러 파라미터를 붙여 최종 캐시 키 문자열 생성.
@@ -123,7 +123,7 @@
 
 ### 캐싱 구현
 
-- [TopProductQueryService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/analytics/application/TopProductQueryService.java)
+- [TopProductQueryService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/analytics/application/TopProductQueryService.java)
   - `@CacheConfig(cacheNames = CacheNames.TOP_PRODUCTS)` 클래스 레벨 지정하여, 각 함수에서 생략
   - 기본 기능 `top5InLast3Days` 는 확장 가능한 `topNLastNDays`함수를 호출하되, 클래스 내부에서 호출하므로, 각각 `@Cacheable`을 적용
   - `top5InLast3Days`는 3일 5개로 고정된 키 발행, `topNLastNDays`는 파라미터에 의해 발행

--- a/docs/concurrency-redis/report.md
+++ b/docs/concurrency-redis/report.md
@@ -9,7 +9,7 @@
 ## `OrderFacadeConcurrencyTest` 통합 테스트 목적
 
 - 사용자 및 상품의 갯수가 충분할 때, 모든 주문이 정상적으로 성공해야 한다.
-- [OrderFacadeConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/test/java/kr/hhplus/be/server/order/facade/OrderFacadeConcurrencyTest.java)
+- [OrderFacadeConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/order/facade/OrderFacadeConcurrencyTest.java)
 
 ### 조건
 
@@ -89,10 +89,10 @@
 
 ### 분산락 커스텀 어노테이션 구현
 
-- [DistributedLock.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/common/lock/DistributedLock.java): 분산락 적용을 위한 커스텀 어노테이션
-  - `prefix`: 도메인 별 `lock`을 획득하기 위한 `key` ([LockKey.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/common/lock/LockKey.java))
+- [DistributedLock.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/common/lock/DistributedLock.java): 분산락 적용을 위한 커스텀 어노테이션
+  - `prefix`: 도메인 별 `lock`을 획득하기 위한 `key` ([LockKey.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/common/lock/LockKey.java))
   - `ids`: 멀티 키를 위한 `id`배열, 주로 `PK`를 사용
-- [DistributedLockAspect.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/common/lock/DistributedLockAspect.java): 커스텀 어노테이션 기반 AOP 구현 클래스 
+- [DistributedLockAspect.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/common/lock/DistributedLockAspect.java): 커스텀 어노테이션 기반 AOP 구현 클래스 
   - `@Order(Ordered.HIGHEST_PRECEDENCE)`: **최우선 순위 보장**
     -  기본 `@Transactional`은 `LOWEST_PRECEDENCE`로 등록됨
   - `lock`함수: @DistributedLock 어노테이션이 붙은 메서드를 실행하기 전 후로, 분산락 처리
@@ -176,7 +176,7 @@
 
 ### 분산락 적용
 
-- [OrderFacade.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/order/facade/OrderFacade.java): 커스컴 AOP 적용
+- [OrderFacade.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/order/facade/OrderFacade.java): 커스컴 AOP 적용
   - `OrderFacade`에서 사용되는 `Product, Coupon, Balance, Order` 중 다른 사용자와 경합이 많이 발생하는 `Product`로 분산락 적용함
   - `Coupon, Balance, Order` 기존 DB락으로 유지
   - 로직 변경없이 `@DistributedLock` 적용 
@@ -207,7 +207,7 @@
 
 ### 조건부 업데이트 쿼리 수정
 
-- [ProductRepository.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/product/domain/ProductRepository.java): 조건부 업데이트 쿼리
+- [ProductRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/product/domain/ProductRepository.java): 조건부 업데이트 쿼리
   - 비관적 락에서 조건부 업데이트 쿼리로 수정
   - 분산락에서 `productId` 단위로 직렬화를 보장하기 때문에, DB 업데이트 시 원자적 차감만을 이용하여 성능적 이점을 확보함
     ```java
@@ -224,7 +224,7 @@
         int decreaseStockIfAvailable(@Param("id") Long id, @Param("qty") int qty);
     }
     ```
-- [ProductService.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/product/application/ProductService.java)
+- [ProductService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/product/application/ProductService.java)
   - `verifyAndDecreaseStock` 내부 로직 변경
     ```java
     @Service
@@ -259,7 +259,7 @@
 ## TestContainer 세팅
 
 ### @Profile("test") 테스트 환경 세팅
-- [IntegrationTestContainersConfig.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/test/java/kr/hhplus/be/server/IntegrationTestContainersConfig.java)
+- [IntegrationTestContainersConfig.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/IntegrationTestContainersConfig.java)
   - 기존에 있던 MySQL 테스트 컨테이너와 병합
   - 단일 Redis를 컨테이너에 띄우고, 기본 포트 6379로 매핑함
     ```java
@@ -298,7 +298,7 @@
 ## `CouponFacadeConcurrencyTest` 쿠폰 선착순 발급 통합 테스트 목적
 
 - 쿠폰의 정해진 개수 만큼만 쿠폰이 발급되어야 한다.
-- [CouponFacadeConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/test/java/kr/hhplus/be/server/coupon/facade/CouponFacadeConcurrencyTest.java)
+- [CouponFacadeConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/coupon/facade/CouponFacadeConcurrencyTest.java)
 
 ### 조건
 

--- a/docs/concurrency-redis/report.md
+++ b/docs/concurrency-redis/report.md
@@ -9,7 +9,7 @@
 ## `OrderFacadeConcurrencyTest` 통합 테스트 목적
 
 - 사용자 및 상품의 갯수가 충분할 때, 모든 주문이 정상적으로 성공해야 한다.
-- [OrderFacadeConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/order/facade/OrderFacadeConcurrencyTest.java)
+- [OrderFacadeConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/test/java/kr/hhplus/be/server/order/facade/OrderFacadeConcurrencyTest.java)
 
 ### 조건
 
@@ -89,10 +89,10 @@
 
 ### 분산락 커스텀 어노테이션 구현
 
-- [DistributedLock.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/common/lock/DistributedLock.java): 분산락 적용을 위한 커스텀 어노테이션
-  - `prefix`: 도메인 별 `lock`을 획득하기 위한 `key` ([LockKey.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/common/lock/LockKey.java))
+- [DistributedLock.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/common/lock/DistributedLock.java): 분산락 적용을 위한 커스텀 어노테이션
+  - `prefix`: 도메인 별 `lock`을 획득하기 위한 `key` ([LockKey.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/common/lock/LockKey.java))
   - `ids`: 멀티 키를 위한 `id`배열, 주로 `PK`를 사용
-- [DistributedLockAspect.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/common/lock/DistributedLockAspect.java): 커스텀 어노테이션 기반 AOP 구현 클래스 
+- [DistributedLockAspect.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/common/lock/DistributedLockAspect.java): 커스텀 어노테이션 기반 AOP 구현 클래스 
   - `@Order(Ordered.HIGHEST_PRECEDENCE)`: **최우선 순위 보장**
     -  기본 `@Transactional`은 `LOWEST_PRECEDENCE`로 등록됨
   - `lock`함수: @DistributedLock 어노테이션이 붙은 메서드를 실행하기 전 후로, 분산락 처리
@@ -176,7 +176,7 @@
 
 ### 분산락 적용
 
-- [OrderFacade.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/order/facade/OrderFacade.java): 커스컴 AOP 적용
+- [OrderFacade.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/order/facade/OrderFacade.java): 커스컴 AOP 적용
   - `OrderFacade`에서 사용되는 `Product, Coupon, Balance, Order` 중 다른 사용자와 경합이 많이 발생하는 `Product`로 분산락 적용함
   - `Coupon, Balance, Order` 기존 DB락으로 유지
   - 로직 변경없이 `@DistributedLock` 적용 
@@ -207,7 +207,7 @@
 
 ### 조건부 업데이트 쿼리 수정
 
-- [ProductRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/product/domain/ProductRepository.java): 조건부 업데이트 쿼리
+- [ProductRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/product/domain/ProductRepository.java): 조건부 업데이트 쿼리
   - 비관적 락에서 조건부 업데이트 쿼리로 수정
   - 분산락에서 `productId` 단위로 직렬화를 보장하기 때문에, DB 업데이트 시 원자적 차감만을 이용하여 성능적 이점을 확보함
     ```java
@@ -224,7 +224,7 @@
         int decreaseStockIfAvailable(@Param("id") Long id, @Param("qty") int qty);
     }
     ```
-- [ProductService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/product/application/ProductService.java)
+- [ProductService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/product/application/ProductService.java)
   - `verifyAndDecreaseStock` 내부 로직 변경
     ```java
     @Service
@@ -259,7 +259,7 @@
 ## TestContainer 세팅
 
 ### @Profile("test") 테스트 환경 세팅
-- [IntegrationTestContainersConfig.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/IntegrationTestContainersConfig.java)
+- [IntegrationTestContainersConfig.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/test/java/kr/hhplus/be/server/IntegrationTestContainersConfig.java)
   - 기존에 있던 MySQL 테스트 컨테이너와 병합
   - 단일 Redis를 컨테이너에 띄우고, 기본 포트 6379로 매핑함
     ```java
@@ -298,7 +298,7 @@
 ## `CouponFacadeConcurrencyTest` 쿠폰 선착순 발급 통합 테스트 목적
 
 - 쿠폰의 정해진 개수 만큼만 쿠폰이 발급되어야 한다.
-- [CouponFacadeConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/coupon/facade/CouponFacadeConcurrencyTest.java)
+- [CouponFacadeConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/test/java/kr/hhplus/be/server/coupon/facade/CouponFacadeConcurrencyTest.java)
 
 ### 조건
 

--- a/docs/concurrency/result-report.md
+++ b/docs/concurrency/result-report.md
@@ -3,7 +3,7 @@
 ## 1. 상품 재고 차감
 
 - 상품의 재고 10개에 대하여 20개의 요청, 5개의 요청에서 요청만큼 재고가 차감, 초과 차감은 되지 않도록 보장
-- [ProductServiceConcurrencyTest](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/test/java/kr/hhplus/be/server/product/application/ProductServiceConcurrencyTest.java)
+- [ProductServiceConcurrencyTest](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/product/application/ProductServiceConcurrencyTest.java)
 
 <details><summary>주요 테스트 코드</summary>
 
@@ -56,9 +56,9 @@
 
 <details><summary>실패 이미지</summary>
 
-![실패-1](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/docs/concurrency/assets/011-decrease-stock-fail.png)
-![실패-2](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/docs/concurrency/assets/012-decrease-stock-fail.png)
-![실패-3](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/docs/concurrency/assets/013-decrease-stock-fail.png)
+![실패-1](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/docs/concurrency/assets/011-decrease-stock-fail.png)
+![실패-2](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/docs/concurrency/assets/012-decrease-stock-fail.png)
+![실패-3](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/docs/concurrency/assets/013-decrease-stock-fail.png)
 
 </details>
 
@@ -72,8 +72,8 @@
 
 ### 동시성 제어 구현
   - `@Lock(LockModeType.PESSIMISTIC_WRITE)` 비관적 락 적용, Service 코드 수정
-  - [ProductRepository.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/product/domain/ProductRepository.java)
-  - [ProductService.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/product/application/ProductService.java)
+  - [ProductRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/product/domain/ProductRepository.java)
+  - [ProductService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/product/application/ProductService.java)
 
 <details><summary>주요 구현 코드</summary>
 
@@ -96,9 +96,9 @@
 
 <details><summary>성공 이미지</summary>
 
-![성공-1](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/docs/concurrency/assets/014-decrease-stock-success.png)
-![성공-2](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/docs/concurrency/assets/015-decrease-stock-success.png)
-![성공-3](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/docs/concurrency/assets/016-decrease-stock-success.png)
+![성공-1](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/docs/concurrency/assets/014-decrease-stock-success.png)
+![성공-2](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/docs/concurrency/assets/015-decrease-stock-success.png)
+![성공-3](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/docs/concurrency/assets/016-decrease-stock-success.png)
 
 </details>
 
@@ -116,7 +116,7 @@
 - 발급 수량이 `3개`인 쿠폰 정책(`CouponPolicy`)에 대하여 `10`개의 스레드로 동시요청 하는 경우, 쿠폰이 초과 발급 되지 않도록 보장
 - 경쟁 조건이 발생하는 지와 트랜젝션에 의한 데드락을 확인하고, `@Version`이나 `@Modifying` 쿼리로 제거가 가능 한지 검증
   - 이전 주차에 이미 `@Version`을 적용하여 해당 부분은 주석처리하고 테스트 코드 작성
-- [CouponFacadeConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/test/java/kr/hhplus/be/server/coupon/facade/CouponFacadeConcurrencyTest.java)
+- [CouponFacadeConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/coupon/facade/CouponFacadeConcurrencyTest.java)
 
 <details><summary>주요 테스트 코드</summary>
 
@@ -191,8 +191,8 @@
 ### 동시성 제어 구현
   - `@Version`을 주석 해제하는 것만으로도 테스트가 통과되는 것을 확인함
   - 추가적인 학습을 위해 `@Modifying` 쿼리를 통한 제어를 구현하여 테스트
-  - [CouponPolicyRepository.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/coupon/domain/CouponPolicyRepository.java)
-  - [CouponService.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponService.java)
+  - [CouponPolicyRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/domain/CouponPolicyRepository.java)
+  - [CouponService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponService.java)
 
 <details><summary>주요 구현 코드</summary>
 
@@ -231,9 +231,9 @@
 
 <details><summary>성공 이미지</summary>
 
-![성공-1](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/docs/concurrency/assets/003-issue-coupon-success.png)
-![성공-2](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/docs/concurrency/assets/004-issue-coupon-success.png)
-![성공-3](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/docs/concurrency/assets/005-issue-coupon-success.png)
+![성공-1](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/docs/concurrency/assets/003-issue-coupon-success.png)
+![성공-2](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/docs/concurrency/assets/004-issue-coupon-success.png)
+![성공-3](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/docs/concurrency/assets/005-issue-coupon-success.png)
 
 </details>
 
@@ -256,7 +256,7 @@
 - 사용자 한명에게 발급된 쿠폰 하나에 대한 10개의 동시 요청 중 1개만 성공하도록 보장
 - `used = true` 값이 무조건 반환되어 단순 결과값만으로는 확인 불가
 - 10회 요청 중 성공과 예외처리를 카운트 하여 경쟁 상태를 확인
-- [CouponServiceConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/test/java/kr/hhplus/be/server/coupon/application/CouponServiceConcurrencyTest.java)
+- [CouponServiceConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/coupon/application/CouponServiceConcurrencyTest.java)
 
 <details><summary>주요 테스트 코드</summary>
 
@@ -312,7 +312,7 @@
 
 <details><summary>실패 이미지</summary>
 
-![실패-1](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/docs/concurrency/assets/021-use-coupon-fail.png)
+![실패-1](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/docs/concurrency/assets/021-use-coupon-fail.png)
 
 </details>
 
@@ -325,8 +325,8 @@
 ### 동시성 제어 구현
 
 - @Modifying 쿼리를 통한 낙관적 동시성 제어 구현
-- [CouponRepository.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/coupon/domain/CouponRepository.java)
-- [CouponService.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponService.java)
+- [CouponRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/domain/CouponRepository.java)
+- [CouponService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponService.java)
 
 <details><summary>주요 구현 코드</summary>
 
@@ -361,7 +361,7 @@
 
 <details><summary>성공 이미지</summary>
 
-![성공](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/docs/concurrency/assets/022-use-coupon-success.png)
+![성공](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/docs/concurrency/assets/022-use-coupon-success.png)
 
 </details>
 
@@ -375,7 +375,7 @@
 ## 4. 잔액 차감 - 주문 중복 요청 & 5. 잔액 충전 및 사용 - 주문과 충전의 충돌, 충전 동시 요청 (테스트 실패)
 
 - 사용자 한명에 대하여 잔액의 차감이 중복으로 발생하거나, 충전과 사용이 동시에 진행되지 않도록 보장
-- [BalanceServiceConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/test/java/kr/hhplus/be/server/balance/application/BalanceServiceConcurrencyTest.java)
+- [BalanceServiceConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/balance/application/BalanceServiceConcurrencyTest.java)
 
 <details><summary>주요 테스트 코드(동시성 문제 확인 실패)</summary>
 
@@ -433,7 +433,7 @@
 
 <details><summary>동시성 문제 확인 불가 이미지</summary>
 
-![확인불가](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/docs/concurrency/assets/023-balance-test-fail.png)
+![확인불가](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/docs/concurrency/assets/023-balance-test-fail.png)
 
 </details>
 
@@ -447,8 +447,8 @@
 ### 동시성 제어 구현
 
 - `@Version` 낙관적 락 적용, 요청 중 하나만 성공해도 로직상 문제 없음
-- [Balance.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/balance/domain/Balance.java)
-- [BalanceService.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/balance/application/BalanceService.java)
+- [Balance.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/balance/domain/Balance.java)
+- [BalanceService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/balance/application/BalanceService.java)
 
 <details><summary>주요 구현 코드</summary>
 
@@ -499,8 +499,8 @@ public class BalanceService {
 
 <details><summary>테스트 통과 유지 이미지</summary>
 
-![유지-1](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/docs/concurrency/assets/024-double-use-balance.png)
-![유지-2](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/docs/concurrency/assets/025-charge-balance.png)
+![유지-1](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/docs/concurrency/assets/024-double-use-balance.png)
+![유지-2](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/docs/concurrency/assets/025-charge-balance.png)
 
 </details>
 

--- a/docs/concurrency/result-report.md
+++ b/docs/concurrency/result-report.md
@@ -3,7 +3,7 @@
 ## 1. 상품 재고 차감
 
 - 상품의 재고 10개에 대하여 20개의 요청, 5개의 요청에서 요청만큼 재고가 차감, 초과 차감은 되지 않도록 보장
-- [ProductServiceConcurrencyTest](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/product/application/ProductServiceConcurrencyTest.java)
+- [ProductServiceConcurrencyTest](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/test/java/kr/hhplus/be/server/product/application/ProductServiceConcurrencyTest.java)
 
 <details><summary>주요 테스트 코드</summary>
 
@@ -72,8 +72,8 @@
 
 ### 동시성 제어 구현
   - `@Lock(LockModeType.PESSIMISTIC_WRITE)` 비관적 락 적용, Service 코드 수정
-  - [ProductRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/product/domain/ProductRepository.java)
-  - [ProductService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/product/application/ProductService.java)
+  - [ProductRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/product/domain/ProductRepository.java)
+  - [ProductService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/product/application/ProductService.java)
 
 <details><summary>주요 구현 코드</summary>
 
@@ -116,7 +116,7 @@
 - 발급 수량이 `3개`인 쿠폰 정책(`CouponPolicy`)에 대하여 `10`개의 스레드로 동시요청 하는 경우, 쿠폰이 초과 발급 되지 않도록 보장
 - 경쟁 조건이 발생하는 지와 트랜젝션에 의한 데드락을 확인하고, `@Version`이나 `@Modifying` 쿼리로 제거가 가능 한지 검증
   - 이전 주차에 이미 `@Version`을 적용하여 해당 부분은 주석처리하고 테스트 코드 작성
-- [CouponFacadeConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/coupon/facade/CouponFacadeConcurrencyTest.java)
+- [CouponFacadeConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/test/java/kr/hhplus/be/server/coupon/facade/CouponFacadeConcurrencyTest.java)
 
 <details><summary>주요 테스트 코드</summary>
 
@@ -191,8 +191,8 @@
 ### 동시성 제어 구현
   - `@Version`을 주석 해제하는 것만으로도 테스트가 통과되는 것을 확인함
   - 추가적인 학습을 위해 `@Modifying` 쿼리를 통한 제어를 구현하여 테스트
-  - [CouponPolicyRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/domain/CouponPolicyRepository.java)
-  - [CouponService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponService.java)
+  - [CouponPolicyRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/coupon/domain/CouponPolicyRepository.java)
+  - [CouponService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/coupon/application/CouponService.java)
 
 <details><summary>주요 구현 코드</summary>
 
@@ -256,7 +256,7 @@
 - 사용자 한명에게 발급된 쿠폰 하나에 대한 10개의 동시 요청 중 1개만 성공하도록 보장
 - `used = true` 값이 무조건 반환되어 단순 결과값만으로는 확인 불가
 - 10회 요청 중 성공과 예외처리를 카운트 하여 경쟁 상태를 확인
-- [CouponServiceConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/coupon/application/CouponServiceConcurrencyTest.java)
+- [CouponServiceConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/test/java/kr/hhplus/be/server/coupon/application/CouponServiceConcurrencyTest.java)
 
 <details><summary>주요 테스트 코드</summary>
 
@@ -325,8 +325,8 @@
 ### 동시성 제어 구현
 
 - @Modifying 쿼리를 통한 낙관적 동시성 제어 구현
-- [CouponRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/domain/CouponRepository.java)
-- [CouponService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponService.java)
+- [CouponRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/coupon/domain/CouponRepository.java)
+- [CouponService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/coupon/application/CouponService.java)
 
 <details><summary>주요 구현 코드</summary>
 
@@ -375,7 +375,7 @@
 ## 4. 잔액 차감 - 주문 중복 요청 & 5. 잔액 충전 및 사용 - 주문과 충전의 충돌, 충전 동시 요청 (테스트 실패)
 
 - 사용자 한명에 대하여 잔액의 차감이 중복으로 발생하거나, 충전과 사용이 동시에 진행되지 않도록 보장
-- [BalanceServiceConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/balance/application/BalanceServiceConcurrencyTest.java)
+- [BalanceServiceConcurrencyTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/test/java/kr/hhplus/be/server/balance/application/BalanceServiceConcurrencyTest.java)
 
 <details><summary>주요 테스트 코드(동시성 문제 확인 실패)</summary>
 
@@ -447,8 +447,8 @@
 ### 동시성 제어 구현
 
 - `@Version` 낙관적 락 적용, 요청 중 하나만 성공해도 로직상 문제 없음
-- [Balance.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/balance/domain/Balance.java)
-- [BalanceService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/balance/application/BalanceService.java)
+- [Balance.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/balance/domain/Balance.java)
+- [BalanceService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/balance/application/BalanceService.java)
 
 <details><summary>주요 구현 코드</summary>
 

--- a/docs/kafka/design.md
+++ b/docs/kafka/design.md
@@ -127,7 +127,7 @@ docker compose -f docker-compose-kafka.yml exec kafka \
 
 ### 주요 코드
 
-- [OrderCompletedMessage.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/kafka/message/OrderCompletedMessage.java)
+- [OrderCompletedMessage.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/kafka/message/OrderCompletedMessage.java)
   ```java
   public record OrderCompletedMessage(
           String orderId,
@@ -140,7 +140,7 @@ docker compose -f docker-compose-kafka.yml exec kafka \
   ```
   - 주문완료 시 kafka에 적재할 메세지 스키마
 
-- [KafkaTopics.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/kafka/KafkaTopics.java)
+- [KafkaTopics.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/kafka/KafkaTopics.java)
   ```java
   @Component
   public class KafkaTopics {
@@ -167,7 +167,7 @@ docker compose -f docker-compose-kafka.yml exec kafka \
     - 로컬 테스트용으로 replicas 1 지정, 실제로는 3 이상 필요,
   - 심화과제를 위해 `couponIssuedTopic` 함께 작성
 
-- [OrderCompletedKafkaPublisher.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/kafka/publisher/OrderCompletedKafkaPublisher.java)
+- [OrderCompletedKafkaPublisher.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/kafka/publisher/OrderCompletedKafkaPublisher.java)
   ```java
   @Slf4j
   @Component
@@ -242,7 +242,7 @@ public class IntegrationTestContainersConfig {
 
 ### 메세지 발행 테스트
 
-- [TopProductServiceRedisTest.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/test/java/kr/hhplus/be/server/analytics/application/TopProductServiceRedisTest.java)
+- [TopProductServiceRedisTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/analytics/application/TopProductServiceRedisTest.java)
   - 기존 Redis 검증용 테스트 파일에 테스트 항목(`kafkaMessageProduced`)을 하나 더 추가했습니다.
 
 - 검증용 테스트 Consumer 추가

--- a/docs/kafka/design.md
+++ b/docs/kafka/design.md
@@ -127,7 +127,7 @@ docker compose -f docker-compose-kafka.yml exec kafka \
 
 ### 주요 코드
 
-- [OrderCompletedMessage.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/kafka/message/OrderCompletedMessage.java)
+- [OrderCompletedMessage.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/kafka/message/OrderCompletedMessage.java)
   ```java
   public record OrderCompletedMessage(
           String orderId,
@@ -140,7 +140,7 @@ docker compose -f docker-compose-kafka.yml exec kafka \
   ```
   - 주문완료 시 kafka에 적재할 메세지 스키마
 
-- [KafkaTopics.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/kafka/KafkaTopics.java)
+- [KafkaTopics.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/kafka/KafkaTopics.java)
   ```java
   @Component
   public class KafkaTopics {
@@ -167,7 +167,7 @@ docker compose -f docker-compose-kafka.yml exec kafka \
     - 로컬 테스트용으로 replicas 1 지정, 실제로는 3 이상 필요,
   - 심화과제를 위해 `couponIssuedTopic` 함께 작성
 
-- [OrderCompletedKafkaPublisher.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/kafka/publisher/OrderCompletedKafkaPublisher.java)
+- [OrderCompletedKafkaPublisher.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/kafka/publisher/OrderCompletedKafkaPublisher.java)
   ```java
   @Slf4j
   @Component
@@ -242,7 +242,7 @@ public class IntegrationTestContainersConfig {
 
 ### 메세지 발행 테스트
 
-- [TopProductServiceRedisTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/analytics/application/TopProductServiceRedisTest.java)
+- [TopProductServiceRedisTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/test/java/kr/hhplus/be/server/analytics/application/TopProductServiceRedisTest.java)
   - 기존 Redis 검증용 테스트 파일에 테스트 항목(`kafkaMessageProduced`)을 하나 더 추가했습니다.
 
 - 검증용 테스트 Consumer 추가

--- a/docs/performance-scenario-k6/design.md
+++ b/docs/performance-scenario-k6/design.md
@@ -89,7 +89,7 @@
   - 특이사항: 마지막 업데이트가 5년 전
 
 - 방법 2: docker-compose-k6.yml 직접 작성, latest 버전 사용 ✅
-  -  [docker-compose-k6.yml](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/docker-compose-k6.yml)
+  -  [docker-compose-k6.yml](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/docker-compose-k6.yml)
     
       <details><summary>세부 코드</summary>
 
@@ -162,7 +162,7 @@ docker-compose -f docker-compose-k6.yml run --rm k6 \
 
 ## 테스트 코드
 
-- [scripts/test.js](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/scripts/test.js): 페르소나 A형(충동 구매형) 사용자에 대한 테스트 작성
+- [scripts/test.js](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/scripts/test.js): 페르소나 A형(충동 구매형) 사용자에 대한 테스트 작성
 
 ### 테스트 시나리오 옵션 및 측정 값 세팅
 
@@ -294,7 +294,7 @@ export const setup = () => {
 - 쿠폰 정책은 테스트 실행 시 5개를 생성하고, 생서된 policyIds를 setup 함수에서 반환 받아서 테스트에 사용
 - 상품 정보의 경우 1~5번 상품을 생성하고, 이에 대한 redis에 Top5 상위 주문을 미리 세팅
 
-- [BootDataInitializer.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/boot/BootDataInitializer.java)
+- [BootDataInitializer.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/boot/BootDataInitializer.java)
 
     <details><summary>DB 세팅 코드</summary>
 
@@ -670,7 +670,7 @@ docker-compose -f docker-compose-k6.yml run --rm \
 
 ### DB 설정 변경 - 해결방법 X
 
-- [docker-compose.yml](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/docker-compose.yml): MySQL Docker 에 세부 설정 추가
+- [docker-compose.yml](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/docker-compose.yml): MySQL Docker 에 세부 설정 추가
   ```yml
   version: '3.8'
 
@@ -719,7 +719,7 @@ docker-compose -f docker-compose-k6.yml run --rm \
 
   ```
   
-- [application.yml](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/resources/application.yml): Hikari 설정 변경
+- [application.yml](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/resources/application.yml): Hikari 설정 변경
 
   ```yml
   spring:
@@ -773,7 +773,7 @@ docker-compose -f docker-compose-k6.yml run --rm \
 
 #### 수정된 멀티락 로직
 
-- [OrderFacade.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/order/facade/OrderFacade.java): `DistributedLock` 제거
+- [OrderFacade.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/order/facade/OrderFacade.java): `DistributedLock` 제거
   ```java
   @Component
   @RequiredArgsConstructor
@@ -796,7 +796,7 @@ docker-compose -f docker-compose-k6.yml run --rm \
     }
   }
   ```
-- [ProductService.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/product/application/ProductService.java): items를 받아서 재고를 차감하는 동안에만 `DistributedLock` 적용
+- [ProductService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/product/application/ProductService.java): items를 받아서 재고를 차감하는 동안에만 `DistributedLock` 적용
   ```java
   @Service
   @RequiredArgsConstructor

--- a/docs/performance-scenario-k6/design.md
+++ b/docs/performance-scenario-k6/design.md
@@ -294,7 +294,7 @@ export const setup = () => {
 - 쿠폰 정책은 테스트 실행 시 5개를 생성하고, 생서된 policyIds를 setup 함수에서 반환 받아서 테스트에 사용
 - 상품 정보의 경우 1~5번 상품을 생성하고, 이에 대한 redis에 Top5 상위 주문을 미리 세팅
 
-- [BootDataInitializer.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/boot/BootDataInitializer.java)
+- [BootDataInitializer.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/boot/BootDataInitializer.java)
 
     <details><summary>DB 세팅 코드</summary>
 
@@ -719,7 +719,7 @@ docker-compose -f docker-compose-k6.yml run --rm \
 
   ```
   
-- [application.yml](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/resources/application.yml): Hikari 설정 변경
+- [application.yml](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/resources/application.yml): Hikari 설정 변경
 
   ```yml
   spring:
@@ -773,7 +773,7 @@ docker-compose -f docker-compose-k6.yml run --rm \
 
 #### 수정된 멀티락 로직
 
-- [OrderFacade.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/order/facade/OrderFacade.java): `DistributedLock` 제거
+- [OrderFacade.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/order/facade/OrderFacade.java): `DistributedLock` 제거
   ```java
   @Component
   @RequiredArgsConstructor
@@ -796,7 +796,7 @@ docker-compose -f docker-compose-k6.yml run --rm \
     }
   }
   ```
-- [ProductService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/product/application/ProductService.java): items를 받아서 재고를 차감하는 동안에만 `DistributedLock` 적용
+- [ProductService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/product/application/ProductService.java): items를 받아서 재고를 차감하는 동안에만 `DistributedLock` 적용
   ```java
   @Service
   @RequiredArgsConstructor

--- a/docs/ranking-event/design.md
+++ b/docs/ranking-event/design.md
@@ -39,14 +39,14 @@
 
 ### 이벤트 관련 클래스 구현
 
-- [OrderCompletedEvent.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/common/event/OrderCompletedEvent.java)
+- [OrderCompletedEvent.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/common/event/OrderCompletedEvent.java)
   ```java
   public record OrderCompletedEvent(Long orderId, Long userId, List<OrderLineSummary> lines) {
   }
   ```
   - 주문 생성 성공 이벤트
 
-- [TopProductEventHandler.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/analytics/application/TopProductEventHandler.java)
+- [TopProductEventHandler.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/analytics/application/TopProductEventHandler.java)
   ```java
   @Component
   @RequiredArgsConstructor
@@ -64,7 +64,7 @@
   - `AFTER_COMMIT` 에 의해 트랜젝션이 커밋 되고 나서 이벤트 동작으로 구현
   - 주문 생성 함수의 `OrderCompletedEvent`를 수집하여 `TopProductService`에 집계 요청
 
-- [TopProductService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/analytics/application/TopProductService.java)
+- [TopProductService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/analytics/application/TopProductService.java)
   ```java
   @Service
   @RequiredArgsConstructor
@@ -88,7 +88,7 @@
   - 상품 번호 및 수량 배열로 RedisRepository에 기록
   - 주문 번호 기록
 
-- [TopProductRedisRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/analytics/infrastructure/TopProductRedisRepository.java)
+- [TopProductRedisRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/analytics/infrastructure/TopProductRedisRepository.java)
   ```java
   @Repository
   @RequiredArgsConstructor
@@ -140,7 +140,7 @@
 
 ### 외부 전송 Mock 핸들러 구현
 
-- [OrderExternalEventHandler.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/external/mock/application/OrderExternalEventHandler.java)
+- [OrderExternalEventHandler.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/external/mock/application/OrderExternalEventHandler.java)
   - `OrderExternalEventHandler` 외부 Mock API 핸들러: 호출 결과를 Redis에 기록
     ```java
     @Slf4j
@@ -168,7 +168,7 @@
     }
     ```
 
-- [OrderExternalRedisRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/external/mock/infrastructure/OrderExternalRedisRepository.java)
+- [OrderExternalRedisRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/external/mock/infrastructure/OrderExternalRedisRepository.java)
   ```java
   @Repository
   @RequiredArgsConstructor
@@ -197,7 +197,7 @@
 
 - Mock 핸들러의 구현 난이도가 낮아 순위 집계 핸들러에 이어서 기능 구현 후 추가 테스트를 작성했습니다.
 
-- [TopProductServiceRedisTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/analytics/application/TopProductServiceRedisTest.java)
+- [TopProductServiceRedisTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/test/java/kr/hhplus/be/server/analytics/application/TopProductServiceRedisTest.java)
   - 첫 번째 테스트는 위 내용에 포함되어있습니다.
   - 추가 테스트 조건은 10번 상품을 등록하고 주문하여, 5위에 집계 되는지, 외부 전송 주문이 기록되는 지 확인했습니다.
   ```java

--- a/docs/ranking-event/design.md
+++ b/docs/ranking-event/design.md
@@ -39,14 +39,14 @@
 
 ### 이벤트 관련 클래스 구현
 
-- [OrderCompletedEvent.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/common/event/OrderCompletedEvent.java)
+- [OrderCompletedEvent.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/common/event/OrderCompletedEvent.java)
   ```java
   public record OrderCompletedEvent(Long orderId, Long userId, List<OrderLineSummary> lines) {
   }
   ```
   - 주문 생성 성공 이벤트
 
-- [TopProductEventHandler.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/analytics/application/TopProductEventHandler.java)
+- [TopProductEventHandler.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/analytics/application/TopProductEventHandler.java)
   ```java
   @Component
   @RequiredArgsConstructor
@@ -64,7 +64,7 @@
   - `AFTER_COMMIT` 에 의해 트랜젝션이 커밋 되고 나서 이벤트 동작으로 구현
   - 주문 생성 함수의 `OrderCompletedEvent`를 수집하여 `TopProductService`에 집계 요청
 
-- [TopProductService.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/analytics/application/TopProductService.java)
+- [TopProductService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/analytics/application/TopProductService.java)
   ```java
   @Service
   @RequiredArgsConstructor
@@ -88,7 +88,7 @@
   - 상품 번호 및 수량 배열로 RedisRepository에 기록
   - 주문 번호 기록
 
-- [TopProductRedisRepository.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/analytics/infrastructure/TopProductRedisRepository.java)
+- [TopProductRedisRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/analytics/infrastructure/TopProductRedisRepository.java)
   ```java
   @Repository
   @RequiredArgsConstructor
@@ -140,7 +140,7 @@
 
 ### 외부 전송 Mock 핸들러 구현
 
-- [OrderExternalEventHandler.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/external/mock/application/OrderExternalEventHandler.java)
+- [OrderExternalEventHandler.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/external/mock/application/OrderExternalEventHandler.java)
   - `OrderExternalEventHandler` 외부 Mock API 핸들러: 호출 결과를 Redis에 기록
     ```java
     @Slf4j
@@ -168,7 +168,7 @@
     }
     ```
 
-- [OrderExternalRedisRepository.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/external/mock/infrastructure/OrderExternalRedisRepository.java)
+- [OrderExternalRedisRepository.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/external/mock/infrastructure/OrderExternalRedisRepository.java)
   ```java
   @Repository
   @RequiredArgsConstructor
@@ -197,7 +197,7 @@
 
 - Mock 핸들러의 구현 난이도가 낮아 순위 집계 핸들러에 이어서 기능 구현 후 추가 테스트를 작성했습니다.
 
-- [TopProductServiceRedisTest.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/test/java/kr/hhplus/be/server/analytics/application/TopProductServiceRedisTest.java)
+- [TopProductServiceRedisTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/analytics/application/TopProductServiceRedisTest.java)
   - 첫 번째 테스트는 위 내용에 포함되어있습니다.
   - 추가 테스트 조건은 10번 상품을 등록하고 주문하여, 5위에 집계 되는지, 외부 전송 주문이 기록되는 지 확인했습니다.
   ```java

--- a/docs/ranking-redis/design.md
+++ b/docs/ranking-redis/design.md
@@ -54,7 +54,7 @@
 
 ### 조건
 
-- [TopProductRedisServiceTest.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/test/java/kr/hhplus/be/server/analytics/application/TopProductRedisServiceTest.java)
+- [TopProductRedisServiceTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/analytics/application/TopProductRedisServiceTest.java)
 - 사용자는 1명으로 고정하여 순수하게 상품과 판매 수량만 집계되는 정보로 통제
 - 잔액이나 상품의 수량은 충분하여 주문이 실패하지 않음
 - 과거 1~3일 전의 데이터는 `setUp` 단계에서 미리 세팅(Product 1번 제외)
@@ -114,7 +114,7 @@
 
 ### Redis 저장 함수 / 집계 로직 구현 
 
-- [TopProductRedisService.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/analytics/application/TopProductRedisService.java)
+- [TopProductRedisService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/analytics/application/TopProductRedisService.java)
 - 주문이 발생할 때 Redis에 반영하기 위한 `TopProductRedisService` 구현
   - 기존 DB 쿼리 기반인 `TopProductQueryService`와 분리하여 구현했습니다.
   - `OrderFacade`에서 사용하는 계층으로 기존 `analytics/application`에 위치시켰습니다.
@@ -201,7 +201,7 @@
 
 ### 주문 생성 시 Redis 저장 로직 구현
 
-- [OrderFacade.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/order/facade/OrderFacade.java) 수정
+- [OrderFacade.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/order/facade/OrderFacade.java) 수정
   - 주문 생성 이후 (트랜젝션 내에서) redis에 비동기 적으로 저장하도록 요청 
     - 기존에 repository에 주문을 저장하면서 return 하는 부분은 order로 담아두고,
     - items 배열에서 ProductId와 quantity만 사용하여 `topProductRedisService`에 비동기로 요청합니다.    
@@ -226,7 +226,7 @@
   - 현재 상태는 트랜젝션 내부에서 실행중이므로, 커밋이 보장되지 않을 수 있음 
   - `Transactional Outbox` 패턴을 추후에 적용하여 이벤트 방식으로 수정 필요
 
-- [TopProductRedisService.java](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/analytics/application/TopProductRedisService.java)
+- [TopProductRedisService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/analytics/application/TopProductRedisService.java)
   - `recordOrdersAsync` 함수 추가
     - `@Async` 어노테이션을 사용하기 위해 OrderFacade 외부에 선언 필요
     - 배열을 받아서 `Redis`에 저장하되, 저장 시마다 `try {} catch (ignored){}` 로 에러가 반환되지 않도록 구현

--- a/docs/ranking-redis/design.md
+++ b/docs/ranking-redis/design.md
@@ -54,7 +54,7 @@
 
 ### 조건
 
-- [TopProductRedisServiceTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/test/java/kr/hhplus/be/server/analytics/application/TopProductRedisServiceTest.java)
+- [TopProductRedisServiceTest.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/test/java/kr/hhplus/be/server/analytics/application/TopProductRedisServiceTest.java)
 - 사용자는 1명으로 고정하여 순수하게 상품과 판매 수량만 집계되는 정보로 통제
 - 잔액이나 상품의 수량은 충분하여 주문이 실패하지 않음
 - 과거 1~3일 전의 데이터는 `setUp` 단계에서 미리 세팅(Product 1번 제외)
@@ -114,7 +114,7 @@
 
 ### Redis 저장 함수 / 집계 로직 구현 
 
-- [TopProductRedisService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/analytics/application/TopProductRedisService.java)
+- [TopProductRedisService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/analytics/application/TopProductRedisService.java)
 - 주문이 발생할 때 Redis에 반영하기 위한 `TopProductRedisService` 구현
   - 기존 DB 쿼리 기반인 `TopProductQueryService`와 분리하여 구현했습니다.
   - `OrderFacade`에서 사용하는 계층으로 기존 `analytics/application`에 위치시켰습니다.
@@ -201,7 +201,7 @@
 
 ### 주문 생성 시 Redis 저장 로직 구현
 
-- [OrderFacade.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/order/facade/OrderFacade.java) 수정
+- [OrderFacade.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/order/facade/OrderFacade.java) 수정
   - 주문 생성 이후 (트랜젝션 내에서) redis에 비동기 적으로 저장하도록 요청 
     - 기존에 repository에 주문을 저장하면서 return 하는 부분은 order로 담아두고,
     - items 배열에서 ProductId와 quantity만 사용하여 `topProductRedisService`에 비동기로 요청합니다.    
@@ -226,7 +226,7 @@
   - 현재 상태는 트랜젝션 내부에서 실행중이므로, 커밋이 보장되지 않을 수 있음 
   - `Transactional Outbox` 패턴을 추후에 적용하여 이벤트 방식으로 수정 필요
 
-- [TopProductRedisService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/analytics/application/TopProductRedisService.java)
+- [TopProductRedisService.java](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/analytics/application/TopProductRedisService.java)
   - `recordOrdersAsync` 함수 추가
     - `@Async` 어노테이션을 사용하기 위해 OrderFacade 외부에 선언 필요
     - 배열을 받아서 `Redis`에 저장하되, 저장 시마다 `try {} catch (ignored){}` 로 에러가 반환되지 않도록 구현

--- a/docs/saga-pattern/design.md
+++ b/docs/saga-pattern/design.md
@@ -160,9 +160,9 @@ stateDiagram-v2
 
 ### 상태 저장소 구성
 
-- [OrderSagaRepository](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/saga/domain/OrderSagaRepository.java): Saga 상태 저장소
-- [OrderSagaEventStatus](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/saga/domain/OrderSagaEventStatus.java) (enum: PENDING, SUCCESS, FAILED, CANCELED, RESTORED)
-- [OrderSagaState](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/saga/domain/OrderSagaState.java): 주문 Saga 상태값
+- [OrderSagaRepository](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/saga/domain/OrderSagaRepository.java): Saga 상태 저장소
+- [OrderSagaEventStatus](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/saga/domain/OrderSagaEventStatus.java) (enum: PENDING, SUCCESS, FAILED, CANCELED, RESTORED)
+- [OrderSagaState](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/saga/domain/OrderSagaState.java): 주문 Saga 상태값
   <details><summary>주요 코드</summary>
   
   ```java
@@ -256,7 +256,7 @@ stateDiagram-v2
 
 ### Saga 상태 머신 핸들러
 
-- [OrderSagaHandler](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/saga/application/OrderSagaHandler.java): Saga의 상태 관리 메타 데이터 및 부가 정보 관리
+- [OrderSagaHandler](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/saga/application/OrderSagaHandler.java): Saga의 상태 관리 메타 데이터 및 부가 정보 관리
   <details><summary>주요 코드</summary>
   
   ```java
@@ -380,7 +380,7 @@ stateDiagram-v2
 
 ### 주문 생성 주체
 
-- [OrderCommandService](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/order/application/OrderCommandService.java): 주문 초기값 생성
+- [OrderCommandService](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/order/application/OrderCommandService.java): 주문 초기값 생성
   <details><summary>주요 코드</summary>
   
   ```java
@@ -412,7 +412,7 @@ stateDiagram-v2
   ```
   </details>
 
-- [OrderEventHandler](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/order/application/OrderEventHandler.java): OrderSagaHandler에 의해 발행된 OrderRequestedEvent 감지하여 `OrderStatus.PENDING`으로 전환
+- [OrderEventHandler](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/order/application/OrderEventHandler.java): OrderSagaHandler에 의해 발행된 OrderRequestedEvent 감지하여 `OrderStatus.PENDING`으로 전환
   <details><summary>주요코드</summary>
   
   ```java
@@ -460,7 +460,7 @@ stateDiagram-v2
 ### 각 도메인별 핸들러 및 테스트
 
 - Product
-  - [ProductCommandService](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/product/application/ProductCommandService.java): 상품 재고 차감/원복 비즈니스 로직
+  - [ProductCommandService](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/product/application/ProductCommandService.java): 상품 재고 차감/원복 비즈니스 로직
     <details><summary>주요 코드</summary>
     
     ```java
@@ -524,7 +524,7 @@ stateDiagram-v2
   - `ProductEventHandler`: 상품 차감 및 원가 반환
   - `ProductCompensationHandler`: 차감된 상품 재고 보상
 - Coupon
-  - [CouponCommandService](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponCommandService.java): 쿠폰 사용/원복 비즈니스 로직
+  - [CouponCommandService](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponCommandService.java): 쿠폰 사용/원복 비즈니스 로직
     <details><summary>주요 코드</summary>
   
     ```java
@@ -574,7 +574,7 @@ stateDiagram-v2
   - `CouponEventHandler`: 쿠폰 사용 및 할인액 반환
   - `CouponCompensationHandler`: 사용된 쿠폰 원복 보상
   - Balance
-  - [BalanceCommandService](https://github.com/hanghae-plus-anveloper/hhplus-e-commerce-java/blob/develop/src/main/java/kr/hhplus/be/server/balance/application/BalanceCommandService.java): 잔액 차감/원복 비즈니스 로직
+  - [BalanceCommandService](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/balance/application/BalanceCommandService.java): 잔액 차감/원복 비즈니스 로직
     <details><summary>주요 코드</summary>
 
     ```java

--- a/docs/saga-pattern/design.md
+++ b/docs/saga-pattern/design.md
@@ -160,9 +160,9 @@ stateDiagram-v2
 
 ### 상태 저장소 구성
 
-- [OrderSagaRepository](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/saga/domain/OrderSagaRepository.java): Saga 상태 저장소
-- [OrderSagaEventStatus](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/saga/domain/OrderSagaEventStatus.java) (enum: PENDING, SUCCESS, FAILED, CANCELED, RESTORED)
-- [OrderSagaState](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/saga/domain/OrderSagaState.java): 주문 Saga 상태값
+- [OrderSagaRepository](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/saga/domain/OrderSagaRepository.java): Saga 상태 저장소
+- [OrderSagaEventStatus](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/saga/domain/OrderSagaEventStatus.java) (enum: PENDING, SUCCESS, FAILED, CANCELED, RESTORED)
+- [OrderSagaState](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/saga/domain/OrderSagaState.java): 주문 Saga 상태값
   <details><summary>주요 코드</summary>
   
   ```java
@@ -256,7 +256,7 @@ stateDiagram-v2
 
 ### Saga 상태 머신 핸들러
 
-- [OrderSagaHandler](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/saga/application/OrderSagaHandler.java): Saga의 상태 관리 메타 데이터 및 부가 정보 관리
+- [OrderSagaHandler](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/saga/application/OrderSagaHandler.java): Saga의 상태 관리 메타 데이터 및 부가 정보 관리
   <details><summary>주요 코드</summary>
   
   ```java
@@ -380,7 +380,7 @@ stateDiagram-v2
 
 ### 주문 생성 주체
 
-- [OrderCommandService](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/order/application/OrderCommandService.java): 주문 초기값 생성
+- [OrderCommandService](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/order/application/OrderCommandService.java): 주문 초기값 생성
   <details><summary>주요 코드</summary>
   
   ```java
@@ -412,7 +412,7 @@ stateDiagram-v2
   ```
   </details>
 
-- [OrderEventHandler](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/order/application/OrderEventHandler.java): OrderSagaHandler에 의해 발행된 OrderRequestedEvent 감지하여 `OrderStatus.PENDING`으로 전환
+- [OrderEventHandler](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/order/application/OrderEventHandler.java): OrderSagaHandler에 의해 발행된 OrderRequestedEvent 감지하여 `OrderStatus.PENDING`으로 전환
   <details><summary>주요코드</summary>
   
   ```java
@@ -460,7 +460,7 @@ stateDiagram-v2
 ### 각 도메인별 핸들러 및 테스트
 
 - Product
-  - [ProductCommandService](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/product/application/ProductCommandService.java): 상품 재고 차감/원복 비즈니스 로직
+  - [ProductCommandService](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/product/application/ProductCommandService.java): 상품 재고 차감/원복 비즈니스 로직
     <details><summary>주요 코드</summary>
     
     ```java
@@ -524,7 +524,7 @@ stateDiagram-v2
   - `ProductEventHandler`: 상품 차감 및 원가 반환
   - `ProductCompensationHandler`: 차감된 상품 재고 보상
 - Coupon
-  - [CouponCommandService](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/coupon/application/CouponCommandService.java): 쿠폰 사용/원복 비즈니스 로직
+  - [CouponCommandService](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/coupon/application/CouponCommandService.java): 쿠폰 사용/원복 비즈니스 로직
     <details><summary>주요 코드</summary>
   
     ```java
@@ -574,7 +574,7 @@ stateDiagram-v2
   - `CouponEventHandler`: 쿠폰 사용 및 할인액 반환
   - `CouponCompensationHandler`: 사용된 쿠폰 원복 보상
   - Balance
-  - [BalanceCommandService](https://github.com/hanghae-plus-anveloper/e-commerce/blob/develop/src/main/java/kr/hhplus/be/server/balance/application/BalanceCommandService.java): 잔액 차감/원복 비즈니스 로직
+  - [BalanceCommandService](https://github.com/hanghae-plus-anveloper/e-commerce/blob/main/src/main/java/kr/hhplus/be/server/balance/application/BalanceCommandService.java): 잔액 차감/원복 비즈니스 로직
     <details><summary>주요 코드</summary>
 
     ```java


### PR DESCRIPTION
Github Organization 과 프로젝트 Prefix 이름 중복으로 인한 프로젝트 명 단순화

- /docs 하위 내용 중 코드 파일 참조중인 링크의 경로 수정
- develop → main 으로 브랜치 참조 경로 수정

